### PR TITLE
Create the DLC directory if it does not already exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Options:
 - change the home folder:``-e USER_HOME=$HOME/DeepLabCut``  (i.e. this can be ``-e USER_HOME=$HOME/whateveryouwant``)
 
 ```
+# Create the DLC directory if it does not already exist
+mkdir -p $HOME/DeepLabCut
+
+# Run the docker container
 GPU=1 bash ./dlc-docker run -d -p 2351:8888 -e USER_HOME=$HOME/DeepLabCut --name containername dlc_username/dlcdocker
 ```
 Do not run this with sudo. 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Options:
 
 ```
 # Create the DLC directory if it does not already exist
-mkdir -p $HOME/DeepLabCut
+mkdir -p $HOME/DeepLabCut # or $HOME/whateveryouwant (see the options above)
 
 # Run the docker container
 GPU=1 bash ./dlc-docker run -d -p 2351:8888 -e USER_HOME=$HOME/DeepLabCut --name containername dlc_username/dlcdocker


### PR DESCRIPTION
This was necessary for the container to start without exiting on error on a fresh install.