### PR TITLE
imagecodes build fail fix (#30)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install imageio-ffmpeg
 FROM bethgelab/deeplearning:cuda9.0-cudnn7
 RUN add-apt-repository ppa:deadsnakes/ppa #ADDS NEW REPO
 RUN add-apt-repository --remove ppa:jonathonf/python-3.6 #REMOVES BROKEN REPO
+RUN apt-get install -y apt-utils
 RUN apt-get update
 RUN apt-get -y install ffmpeg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN add-apt-repository --remove ppa:jonathonf/python-3.6 #REMOVES BROKEN REPO
 RUN apt-get update
 RUN apt-get -y install ffmpeg
 
-#RUN pip install --upgrade pip #see issue #25
+
 RUN pip install tensorflow-gpu==1.8
+#see issue #25:
+RUN pip install --upgrade pip 
+
 RUN pip install ruamel_yaml
 RUN pip3 install deeplabcutcore
 RUN pip install ipywidgets

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN pip install imageio-ffmpeg
 FROM bethgelab/deeplearning:cuda9.0-cudnn7
 RUN add-apt-repository ppa:deadsnakes/ppa #ADDS NEW REPO
 RUN add-apt-repository --remove ppa:jonathonf/python-3.6 #REMOVES BROKEN REPO
-RUN apt-get install -y apt-utils
 RUN apt-get update
 RUN apt-get -y install ffmpeg
 
 #RUN pip install --upgrade pip #see issue #25
 RUN pip install tensorflow-gpu==1.8
+RUN pip install ruamel_yaml
 RUN pip3 install deeplabcutcore
 RUN pip install ipywidgets
 RUN pip3 install ipywidgets


### PR DESCRIPTION
- forcing pip update before wheel of imagecodecs is installed resolves #30.