### PR TITLE
Update "Install nvidia-docker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Test docker:
 **(2)** Install nvidia-docker, see https://nvidia.github.io/nvidia-docker/.
 But, basically it is just: 
 
+
+    $ curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
+    sudo apt-key add -
+    $ distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+    $ curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
+    sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+    $ sudo apt-get update
     $ sudo apt-get install nvidia-docker2
   
   *you can also run: ``sudo docker run --runtime=nvidia --rm nvidia/cuda:9.0-base nvidia-smi`` to test your nvidia-docker, and if you get the error ``docker: Error response from daemon: Unknown runtime specified nvidia.`` just simply restart docker: 


### PR DESCRIPTION
`$ sudo apt-get install nvidia-docker2` alone results in the following error (tested in Ubuntu 16.04 and 18.04):
```
ubuntu@ubuntu:~$ sudo apt-get install nvidia-docker2
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package nvidia-docker2
```
Also see: [issue#716](https://github.com/NVIDIA/nvidia-docker/issues/716).

This is solved by setting up the nvidia-docker repository as outlined here: https://nvidia.github.io/nvidia-docker/