### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN pip install imageio-ffmpeg
 FROM bethgelab/deeplearning:cuda9.0-cudnn7
 RUN add-apt-repository ppa:deadsnakes/ppa #ADDS NEW REPO
 RUN add-apt-repository --remove ppa:jonathonf/python-3.6 #REMOVES BROKEN REPO
-RUN apt-get update
-RUN apt-get -y install ffmpeg
+RUN apt-get update && apt-get -y install ffmpeg && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 RUN pip install tensorflow-gpu==1.8


### PR DESCRIPTION
Cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down. Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install (see [here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)). On a side note, clean up must be performed in the same RUN step, otherwise it will not affect image size.